### PR TITLE
Improve tika for scan documents in PDF formats

### DIFF
--- a/src/main/java/uk/ac/kcl/itemProcessors/TikaDocumentItemProcessor.java
+++ b/src/main/java/uk/ac/kcl/itemProcessors/TikaDocumentItemProcessor.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright 2016 King's College London, Richard Jackson <richgjackson@gmail.com>.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,9 +28,9 @@ import org.springframework.stereotype.Service;
 import org.xml.sax.ContentHandler;
 import uk.ac.kcl.model.Document;
 
-import javax.annotation.PostConstruct;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import javax.annotation.PostConstruct;
 
 /**
  *
@@ -73,13 +73,13 @@ public class TikaDocumentItemProcessor extends TLItemProcessor implements ItemPr
         } else {
             handler = new BodyContentHandler();
         }
-        ;
+
         Metadata metadata = new Metadata();
         try (InputStream stream = new ByteArrayInputStream(doc.getBinaryContent())) {
             parser.parse(stream, handler, metadata);
             addField(doc, handler.toString());
         } catch (Exception ex) {
-            addField(doc,ex.getMessage());
+            addField(doc, ex.getMessage());
         }
         LOG.debug("finished " + this.getClass().getSimpleName() +" on doc " +doc.getDocName());
         return doc;

--- a/src/main/java/uk/ac/kcl/tika/parsers/PDFPreprocessorParser.java
+++ b/src/main/java/uk/ac/kcl/tika/parsers/PDFPreprocessorParser.java
@@ -128,8 +128,13 @@ public class PDFPreprocessorParser extends AbstractParser {
         //if there's content - reparse with official handlers/metadata. What else can you do? Also check imagemagick is available
         if (body.toString().length() > 100 || !hasImageMagick(config)) {
             pdfParser.parse(stream, handler, metadata, context);
+            metadata.set("X-PDFPREPROC-OCR-APPLIED", "NA");
             return;
         } else {
+            metadata.set("X-PDFPREPROC-ORIGINAL", body.toString());
+            metadata.set("X-PDFPREPROC-OCR-APPLIED", "FAIL");
+            // "FAIL" will be overwritten if it succeeds later
+
             //add the PDF metadata to the official metadata object
             Arrays.asList(pdfMetadata.names()).stream().forEach(name -> {
                 metadata.add(name, pdfMetadata.get(name));
@@ -147,6 +152,7 @@ public class PDFPreprocessorParser extends AbstractParser {
             if (tiffFileOfPDF.exists()) {
                 TesseractOCRParser tesseract = new TesseractOCRParser();
                 tesseract.parse(FileUtils.openInputStream(tiffFileOfPDF), handler, metadata, context);
+                metadata.set("X-PDFPREPROC-OCR-APPLIED", "SUCCESS");
             }
         } finally {
             if (tiffFileOfPDF.exists()) {

--- a/src/main/java/uk/ac/kcl/tika/parsers/PDFPreprocessorParser.java
+++ b/src/main/java/uk/ac/kcl/tika/parsers/PDFPreprocessorParser.java
@@ -169,8 +169,12 @@ public class PDFPreprocessorParser extends AbstractParser {
     }
 
     private File makeTiffFromPDF(File input, File output, ImageMagickConfig config) throws IOException, TikaException {
-        String[] cmd = {config.getImageMagickPath() + getImageMagickProg(), "-density", config.getDensity(),
-                input.getPath(), "-depth", config.getDepth(), "-quality", config.getQuality(), output.getPath()};
+        String[] cmd = {config.getImageMagickPath() + getImageMagickProg(),
+                        "-density", config.getDensity(), input.getPath(),
+                        "-depth", config.getDepth(),
+                        "-quality", config.getQuality(),
+                        "-background", "white", "-flatten", "+matte",
+                        output.getPath()};
 
         ProcessBuilder pb = new ProcessBuilder(cmd);
         //setEnv(config, pb);


### PR DESCRIPTION
- Use tika-config.xml explicitly
- Store original text parsed from PDF (before OCR) in metadata
- Change image magick command (which increase successful parsing rate)
